### PR TITLE
Fix migration job command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,11 +217,10 @@ jobs:
           --image $IMAGE_URL:$GITHUB_SHA \
           --region ${{ env.REGION }} \
           --service-account ${{ env.GCP_SA_EMAIL }} \
-          --add-cloudsql-instances ${{ env.CLOUDSQL_INSTANCE }} \
+          --set-cloudsql-instances ${{ env.CLOUDSQL_INSTANCE }} \
           --set-secrets "DATABASE_URL=db-app-password:latest" \
           --command "flask" \
-          --args "db,upgrade" \
-          --replace
+          --args "db,upgrade"
           
         gcloud run jobs execute migrate-database-staging --region ${{ env.REGION }} --wait
 

--- a/document-generator-frontend/Dockerfile
+++ b/document-generator-frontend/Dockerfile
@@ -2,13 +2,11 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-COPY package*.json ./
-COPY pnpm-lock.yaml ./
-COPY . .
+COPY package.json pnpm-lock.yaml ./
+RUN npm install -g pnpm && pnpm install
 
-RUN npm install -g pnpm \
-    && pnpm install \
-    && pnpm run build
+COPY . .
+RUN pnpm run build
 
 # Production stage
 FROM nginx:1.25-alpine


### PR DESCRIPTION
## Summary
- remove the invalid `--replace` flag from the staging migration job
- ensure Cloud SQL instances are set using `--set-cloudsql-instances`

## Testing
- `pnpm install --no-frozen-lockfile`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fc6b750b8832f9797d8f486a30ac5