### PR TITLE
Improve Cloud Run deployment with Cloud SQL connector

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,8 +184,9 @@ jobs:
           --region ${{ env.REGION }} \
           --allow-unauthenticated \
           --service-account ${{ secrets.GCP_APP_SA_EMAIL }} \
-          --add-cloudsql-instances ${{ env.CLOUDSQL_INSTANCE }} \
-          --set-secrets "DATABASE_URL=db-app-password:latest" \
+          --set-cloudsql-instances ${{ env.CLOUDSQL_INSTANCE }} \
+          --set-env-vars "DB_USER=app_user,DB_NAME=document_generator,INSTANCE_CONNECTION_NAME=${{ env.CLOUDSQL_INSTANCE }}" \
+          --set-secrets "DB_PASS=db-app-password:latest" \
           --tag staging
 
         BACKEND_URL=$(gcloud run services describe ${{ env.BACKEND_SERVICE }} --region=${{ env.REGION }} --format="value(status.url)")
@@ -218,7 +219,8 @@ jobs:
           --region ${{ env.REGION }} \
           --service-account ${{ env.GCP_APP_SA_EMAIL }} \
           --set-cloudsql-instances ${{ env.CLOUDSQL_INSTANCE }} \
-          --set-secrets "DATABASE_URL=db-app-password:latest" \
+          --set-env-vars="DB_USER=app_user,DB_NAME=document_generator,INSTANCE_CONNECTION_NAME=${{ env.CLOUDSQL_INSTANCE }}" \
+          --set-secrets="DB_PASS=db-app-password:latest" \
           --set-env-vars "FLASK_APP=src.main:app" \
           --command "flask" \
           --args "db,upgrade"
@@ -281,8 +283,9 @@ jobs:
           --region $REGION \
           --allow-unauthenticated \
           --service-account ${{ secrets.GCP_APP_SA_EMAIL }} \
-          --add-cloudsql-instances ${{ secrets.CLOUDSQL_INSTANCE }} \
-          --set-secrets "DATABASE_URL=database-url:latest,JWT_SECRET_KEY=jwt-secret-key:latest" \
+          --set-cloudsql-instances ${{ secrets.CLOUDSQL_INSTANCE }} \
+          --set-env-vars "DB_USER=app_user,DB_NAME=document_generator,INSTANCE_CONNECTION_NAME=${{ secrets.CLOUDSQL_INSTANCE }}" \
+          --set-secrets "DB_PASS=db-app-password:latest,JWT_SECRET_KEY=jwt-secret-key:latest" \
           --memory 2Gi \
           --cpu 2 \
           --concurrency 80 \
@@ -343,7 +346,8 @@ jobs:
           --region $REGION \
           --service-account ${{ secrets.GCP_APP_SA_EMAIL }} \
           --set-cloudsql-instances ${{ secrets.CLOUDSQL_INSTANCE }} \
-          --set-secrets "DATABASE_URL=database-url:latest" \
+          --set-env-vars "DB_USER=app_user,DB_NAME=document_generator,INSTANCE_CONNECTION_NAME=${{ secrets.CLOUDSQL_INSTANCE }}" \
+          --set-secrets "DB_PASS=db-app-password:latest" \
           --command "python" \
           --args "-c,\"from src.models.database import db; db.create_all(); print('Database tables created successfully')\""
         

--- a/document-generator-backend/requirements.txt
+++ b/document-generator-backend/requirements.txt
@@ -39,3 +39,4 @@ typing_extensions==4.14.0
 uritemplate==4.2.0
 urllib3==2.4.0
 Werkzeug==3.1.3
+cloud-sql-python-connector

--- a/document-generator-frontend/Dockerfile
+++ b/document-generator-frontend/Dockerfile
@@ -30,7 +30,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Maak poort 80 beschikbaar voor NGINX
-EXPOSE 80
+EXPOSE 8080
 
 # Start NGINX op de voorgrond wanneer de container start
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- fix python dependency for Cloud SQL connector
- expose frontend container on port 8080
- set database env vars for Cloud Run services and jobs
- add `.gitkeep` for backend SQLite dir

## Testing
- `pnpm run build`
- `python -m pip install -r requirements.txt`
- `python create_tables.py`


------
https://chatgpt.com/codex/tasks/task_e_684fedd4e9a8832faf291f36ced4c3e0