### PR TITLE
Fix Gunicorn invocation in Dockerfile

### DIFF
--- a/document-generator-backend/Dockerfile
+++ b/document-generator-backend/Dockerfile
@@ -18,6 +18,6 @@ COPY . .
 # Definieer de poort die de container zal exposen
 EXPOSE 8080
 
-# Start de applicatie met Gunicorn via de correcte app-instantie in app.py
+# Start de applicatie met Gunicorn door de app factory aan te roepen
 # Dit leest de $PORT variabele die Cloud Run aanlevert
-CMD exec gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 app:app
+CMD exec gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 "src.main:create_app()"


### PR DESCRIPTION
## Summary
- call the Flask app factory in Gunicorn CMD so Cloud Run can start the app

## Testing
- `pip install -r requirements.txt` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_685323c54258832fa8b6cac10c445c2f