### PR TITLE
Specify pnpm lockfile path for CI caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,11 @@ jobs:
       with:
         node-version: '20'
         cache: 'pnpm'
+        # DEZE REGEL IS DE OPLOSSING:
+        cache-dependency-path: 'document-generator-frontend/pnpm-lock.yaml'
     - name: Install dependencies
       working-directory: ./document-generator-frontend
-      run: pnpm install --no-frozen-lockfile # Correcte commando
+      run: pnpm install --no-frozen-lockfile
     - name: Build application
       working-directory: ./document-generator-frontend
       run: pnpm run build


### PR DESCRIPTION
## Summary
- ensure the `test-frontend` job caches dependencies using the correct lockfile

## Testing
- `pnpm install --frozen-lockfile=false`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853b1acc488832faee5bd253c544ac8