### PR TITLE
Fix duplicate model import and add frontend entry

### DIFF
--- a/document-generator-backend/src/main.py
+++ b/document-generator-backend/src/main.py
@@ -12,14 +12,14 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Import database and models
-from models.database import db
-from models.organization import Organization
-from models.user import User
-from models.customer import Customer, CustomerAddress, CustomerContact
-from models.product import Product, ProductCategory, ProductAttachment
-from models.order import Order, OrderItem
-from models.document import DocumentTemplate, GeneratedDocument
-from models.system import SystemSetting, WidgetConfiguration, SheetsyncLog, AuditLog
+from src.models.database import db
+from src.models.organization import Organization
+from src.models.user import User
+from src.models.customer import Customer, CustomerAddress, CustomerContact
+from src.models.product import Product, ProductCategory, ProductAttachment
+from src.models.order import Order, OrderItem
+from src.models.document import DocumentTemplate, GeneratedDocument
+from src.models.system import SystemSetting, WidgetConfiguration, SheetsyncLog, AuditLog
 
 # Import routes
 from routes.auth import auth_bp

--- a/document-generator-frontend/index.html
+++ b/document-generator-frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document Generator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- fix imports in backend `main.py` so models are loaded via the same package path
- add missing `index.html` for the Vite build

## Testing
- `DATABASE_URL=sqlite:///test.db python - <<'EOF'
  import sys
  sys.path.insert(0, 'src')
  from src.main import create_app
  app = create_app()
  print('App created')
  EOF`
- `pnpm install`
- `pnpm run build` *(fails: Rollup failed to resolve "@/contexts/AuthContext")*

------
https://chatgpt.com/codex/tasks/task_e_68583ff00578832f8bea0010c98dbb34