### PR TITLE
Restore Vite config and path mapping

### DIFF
--- a/document-generator-frontend/jsconfig.json
+++ b/document-generator-frontend/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    }
+  }
+}

--- a/document-generator-frontend/vite.config.js
+++ b/document-generator-frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- add missing `vite.config.js` for React frontend
- add `jsconfig.json` to support path mapping

## Testing
- `python3 -m pip install -r document-generator-backend/requirements.txt`
- `python3 -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_685841eb09e8832f8a2fb9f042276f05