### PR TITLE
Fix CI test context and Vite alias

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,10 +62,10 @@ jobs:
         DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
         JWT_SECRET_KEY: test-secret-key
         FLASK_ENV: testing
-        PYTHONPATH: /home/runner/work/document-generator/document-generator/document-generator-backend/src
+        PYTHONPATH: "${{ github.workspace }}/document-generator-backend:${{ github.workspace }}/document-generator-backend/src"
       run: |
         # Create test database tables
-        python -c "import sys; sys.path.insert(0, 'src'); from models.database import db; from src.main import create_app; app = create_app(); app.app_context().push(); db.create_all()"
+        python -c "from src.models.database import db; from src.main import create_app; app = create_app(); app.app_context().push(); db.create_all()"
         
         echo "Backend tests passed"
 
@@ -227,7 +227,7 @@ jobs:
           --set-secrets "DATABASE_URL=database-url-staging:latest" \
           --set-env-vars "PYTHONPATH=/app/src:/app" \
           --command "python" \
-          --args "-c,from models.database import db; from main import create_app; app = create_app(); app.app_context().push(); db.create_all(); print('Database tables created successfully')" \
+          --args "-c,from src.models.database import db; from src.main import create_app; app = create_app(); app.app_context().push(); db.create_all(); print('Database tables created successfully')" \
           --replace || true
         
         gcloud run jobs execute migrate-database-staging --region ${{ env.REGION }} --wait
@@ -334,7 +334,7 @@ jobs:
           --set-secrets "DATABASE_URL=database-url:latest" \
           --set-env-vars "PYTHONPATH=/app/src:/app" \
           --command "python" \
-          --args "-c,from models.database import db; from main import create_app; app = create_app(); app.app_context().push(); db.create_all(); print('Database tables created successfully')" \
+          --args "-c,from src.models.database import db; from src.main import create_app; app = create_app(); app.app_context().push(); db.create_all(); print('Database tables created successfully')" \
           --replace || true
         
         gcloud run jobs execute migrate-database --region ${{ env.REGION }} --wait

--- a/document-generator-frontend/vite.config.js
+++ b/document-generator-frontend/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- fix PYTHONPATH and database init command in CI
- configure Vite alias for `@`

## Testing
- `pnpm run build`
- `PYTHONPATH=$(pwd):$(pwd)/src DATABASE_URL=sqlite:///test_pipeline.db python -c "from src.models.database import db; from src.main import create_app; app = create_app(); app.app_context().push(); db.create_all(); print('done')"`


------
https://chatgpt.com/codex/tasks/task_e_6858446587c8832f905e2bcffef38c43