### PR TITLE
Fix staging authentication with Workload Identity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,10 +130,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - id: 'auth'
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.SERVICE_ACCOUNT_EMAIL }}
+
     - name: Set up Google Cloud CLI
       uses: google-github-actions/setup-gcloud@v1
       with:
-        service_account_key: ${{ secrets.GOOGLE_CLOUD_SA_KEY }}
         project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
 
     - name: Configure Docker to use gcloud as a credential helper


### PR DESCRIPTION
## Summary
- authenticate staging deploy via `google-github-actions/auth`
- use Workload Identity Federation instead of service account key

## Testing
- `yamllint .github/workflows/deploy.yml` *(fails: trailing spaces and long lines)*

------
https://chatgpt.com/codex/tasks/task_e_685846f2f874832fb39897458b1f788d