### PR TITLE
Fix Google Cloud authentication via Workload Identity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,10 +251,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - id: 'auth'
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.SERVICE_ACCOUNT_EMAIL }}
+
     - name: Set up Google Cloud CLI
       uses: google-github-actions/setup-gcloud@v1
       with:
-        service_account_key: ${{ secrets.GOOGLE_CLOUD_SA_KEY }}
         project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
 
     - name: Configure Docker to use gcloud as a credential helper


### PR DESCRIPTION
## Summary
- update production deploy job to authenticate with Workload Identity Federation

## Testing
- `python -m compileall -q document-generator-backend`
- `node -v`
- `pnpm -v`
- `python - <<'EOF'
import yaml
with open('.github/workflows/deploy.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68584a08d9fc832f8eb7e81dd4550564