### PR TITLE
Add reconfigure flag to Terraform init

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -80,8 +80,11 @@ db_disk_size      = $(grep "disk_size:" ../config.yaml | sed 's/.*disk_size: *\(
 EOF
 
 # Initialize and apply Terraform
+# Clean up any existing local Terraform data to avoid backend configuration errors
+# (equivalent to running "rm -rf terraform/.terraform*" from the repository root)
 echo "Initializing Terraform..."
-terraform init
+rm -rf .terraform*
+terraform init -reconfigure
 
 echo "Planning infrastructure..."
 terraform plan -var-file="terraform.tfvars" -out=tfplan


### PR DESCRIPTION
## Summary
- clean up old Terraform data before initializing
- use `terraform init -reconfigure` to handle backend changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68586002d078832f849d8f75242e4b0d