### PR TITLE
Add explicit access_token variable for Terraform provider

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,6 +27,7 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
+  access_token = var.access_token
 }
 
 provider "google-beta" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,6 +17,14 @@ variable "zone" {
   default     = "europe-west4-a"
 }
 
+variable "access_token" {
+  description = "Temporary GCP access token for debugging"
+  type        = string
+  sensitive   = true
+  nullable    = true
+  default     = null
+}
+
 variable "environment" {
   description = "Environment name (development, staging, production)"
   type        = string


### PR DESCRIPTION
## Summary
- allow specifying an explicit access_token in the Google provider
- add sensitive `access_token` variable for injecting token

## Testing
- `python3 --version`
- `node --version`
- `python3 - <<'EOF'
import yaml, sys
with open('config.yaml') as f:
    try:
        yaml.safe_load(f)
        print('YAML valid')
    except yaml.YAMLError as e:
        print('YAML invalid:', e)
        sys.exit(1)
EOF`
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68589315e6d8832f97e519e460af988f