### PR TITLE
Run DB migrations before start

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "backend/Dockerfile"
   },
   "deploy": {
-    "startCommand": "gunicorn --bind 0.0.0.0:$PORT --workers 2 --timeout 120 src.main:app",
+    "startCommand": "flask db upgrade && gunicorn --bind 0.0.0.0:$PORT --workers 2 --timeout 120 src.main:app",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary
- ensure database migrations run before launching Gunicorn by updating `startCommand`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68602b5db8b8832f81df0bc2a6168a1b