### PR TITLE
Fix deployment config and clean repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Ignore node modules
+frontend/node_modules/
+
+# Python cache
+**/__pycache__/
+
+# Virtualenv
+.env/
+venv/
+
+# Temporary files
+*.pyc
+*.pyo
+*.pyd
+__pycache__/
+
+# pnpm
+frontend/pnpm-lock.yaml

--- a/RAILWAY-DEPLOYMENT-GUIDE.md
+++ b/RAILWAY-DEPLOYMENT-GUIDE.md
@@ -119,7 +119,7 @@ VITE_API_BASE_URL=https://your-railway-backend-url.railway.app/api
     "dockerfilePath": "backend/Dockerfile"  // Pad naar Dockerfile
   },
   "deploy": {
-    "startCommand": "gunicorn --bind 0.0.0.0:$PORT --workers 2 src.main:app",
+    "startCommand": "gunicorn --bind 0.0.0.0:$PORT --workers 2 --timeout 120 src.main:app",
     "healthcheckPath": "/health",      // Health check endpoint
     "restartPolicyType": "ON_FAILURE"  // Restart bij crashes
   }

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "backend/Dockerfile"
   },
   "deploy": {
-    "startCommand": "flask --app src.main:create_app db upgrade && gunicorn --bind 0.0.0.0:$PORT --workers 2 --timeout 120 'src.main:create_app()'",
+    "startCommand": "gunicorn --bind 0.0.0.0:$PORT --workers 2 --timeout 120 src.main:app",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",
@@ -14,8 +14,7 @@
   "environments": {
     "production": {
       "variables": {
-        "FLASK_ENV": "production",
-        "PYTHONPATH": "/app/backend"
+        "FLASK_ENV": "production"
       }
     }
   }


### PR DESCRIPTION
## Summary
- update `railway.json` start command to use gunicorn directly
- drop unnecessary `PYTHONPATH` override
- document the updated start command in the deployment guide
- add a basic `.gitignore`

## Testing
- `python -m py_compile backend/src/*.py backend/src/models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686037d9be3c832f94042c4523cec862