### PR TITLE
Fix port default and reduce restart retries

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
+# Default port if Railway does not inject one
+ENV PORT=8080
+
 # Install system dependencies
 RUN apt-get update
 RUN apt-get install -y gcc g++ curl

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,9 @@ FROM node:20-alpine AS builder
 # Set working directory
 WORKDIR /app
 
+# Default port if Railway does not inject one
+ENV PORT=8080
+
 # Copy package files
 COPY frontend/package*.json ./
 COPY frontend/pnpm-lock.yaml* ./

--- a/railway.json
+++ b/railway.json
@@ -9,7 +9,7 @@
     "healthcheckPath": "/health",
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+    "restartPolicyMaxRetries": 3
   },
   "environments": {
     "production": {


### PR DESCRIPTION
## Summary
- set default `PORT=8080` in backend and frontend Dockerfiles so gunicorn/nginx run even if `PORT` is unset
- reduce restart attempts from 10 to 3 in `railway.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68603a48aabc832fb8cb568e41d99266