### PR TITLE
Fix missing models and blueprint references

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
+# Default port if Railway does not inject one
+ENV PORT=8080
+
 # Install system dependencies
 RUN apt-get update
 RUN apt-get install -y gcc g++ curl

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -13,23 +13,11 @@ load_dotenv()
 
 # Import database and models
 from models.database import db
-from models.organization import Organization
+# Only import models that exist in this lightweight example
 from models.user import User
-from models.customer import Customer, CustomerAddress, CustomerContact
-from models.product import Product, ProductCategory, ProductAttachment
-from models.order import Order, OrderItem
-from models.document import DocumentTemplate, GeneratedDocument
-from models.system import SystemSetting, WidgetConfiguration, SheetsyncLog, AuditLog
 
 # Import routes
-from routes.auth import auth_bp
-from routes.users import users_bp
-from routes.customers import customers_bp
-from routes.products import products_bp
-from routes.orders import orders_bp
-from routes.documents import documents_bp
-from routes.dashboard import dashboard_bp
-from routes.admin import admin_bp
+# Blueprints for extra routes are optional and not provided in this repo
 
 def create_app(config_name='production'):
     """Application factory pattern - Railway optimized"""
@@ -88,15 +76,8 @@ def create_app(config_name='production'):
     # Enable CORS for all routes
     CORS(app, origins="*", supports_credentials=True)
     
-    # Register blueprints
-    app.register_blueprint(auth_bp, url_prefix='/api/auth')
-    app.register_blueprint(users_bp, url_prefix='/api/users')
-    app.register_blueprint(customers_bp, url_prefix='/api/customers')
-    app.register_blueprint(products_bp, url_prefix='/api/products')
-    app.register_blueprint(orders_bp, url_prefix='/api/orders')
-    app.register_blueprint(documents_bp, url_prefix='/api/documents')
-    app.register_blueprint(dashboard_bp, url_prefix='/api/dashboard')
-    app.register_blueprint(admin_bp, url_prefix='/api/admin')
+    # Blueprint registration is omitted because the blueprints are not
+    # included in this simplified repository. Add them here when available.
     
     # Health check endpoint for Railway
     @app.route('/health')

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,9 @@ FROM node:20-alpine AS builder
 # Set working directory
 WORKDIR /app
 
+# Default port if Railway does not inject one
+ENV PORT=8080
+
 # Copy package files
 COPY frontend/package*.json ./
 COPY frontend/pnpm-lock.yaml* ./

--- a/railway.json
+++ b/railway.json
@@ -5,11 +5,11 @@
     "dockerfilePath": "backend/Dockerfile"
   },
   "deploy": {
-    "startCommand": "gunicorn --bind 0.0.0.0:$PORT --workers 2 --timeout 120 src.main:app",
+    "startCommand": "sh -c 'gunicorn --bind 0.0.0.0:${PORT:-8080} --workers 2 --timeout 120 src.main:app'",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+    "restartPolicyMaxRetries": 3
   },
   "environments": {
     "production": {


### PR DESCRIPTION
## Summary
- remove references to non-existent models and blueprints
- keep existing gunicorn start command with a default port
- ensure Dockerfiles expose default PORT and Railway retries are reasonable

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68603a48aabc832fb8cb568e41d99266