### PR TITLE
Improve frontend-backend integration

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -39,6 +39,7 @@ SECRET_KEY=flask-secret-key
 **Optie B: Vercel (Sneller)**
 - Ga naar **vercel.com** → Import repo → Root: `frontend`
 - Environment: `VITE_API_BASE_URL=https://your-railway-backend.railway.app/api`
+- Of kopieer `frontend/.env.example` naar `frontend/.env` en pas de URL aan
 
 ## ✅ Klaar!
 

--- a/RAILWAY-DEPLOYMENT-GUIDE.md
+++ b/RAILWAY-DEPLOYMENT-GUIDE.md
@@ -248,6 +248,7 @@ CNAME documentgenerator your-app.railway.app
 ```bash
 # Update frontend environment:
 VITE_API_BASE_URL=https://your-railway-backend-url.railway.app/api
+# Of kopieer `frontend/.env.example` naar `frontend/.env` en pas de URL aan
 
 # Of update nginx.conf proxy_pass:
 location /api/ {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://your-backend-url.onrailway.app/api

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,7 +9,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.node },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import { FileText, Users, BarChart3, Settings, Plus, Download, Eye, Edit } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
@@ -8,10 +8,17 @@ import { Input } from '@/components/ui/input.jsx'
 import { Label } from '@/components/ui/label.jsx'
 import { Textarea } from '@/components/ui/textarea.jsx'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
+import { fetchApiInfo } from '@/lib/api.js'
 import './App.css'
 
 // Homepage Component
 function HomePage() {
+  const [apiInfo, setApiInfo] = useState(null)
+  useEffect(() => {
+    fetchApiInfo()
+      .then(setApiInfo)
+      .catch((err) => console.error('API error', err))
+  }, [])
   const stats = [
     { title: 'Documenten Gegenereerd', value: '1,234', icon: FileText, color: 'text-blue-600' },
     { title: 'Actieve Klanten', value: '89', icon: Users, color: 'text-green-600' },
@@ -52,6 +59,11 @@ function HomePage() {
         <div className="mb-8">
           <h2 className="text-3xl font-bold text-gray-900 mb-2">Welkom bij Document Generator</h2>
           <p className="text-lg text-gray-600">Genereer professionele documenten met gemak en snelheid</p>
+          {apiInfo && (
+            <pre className="mt-4 bg-gray-100 p-4 text-sm rounded">
+              {JSON.stringify(apiInfo, null, 2)}
+            </pre>
+          )}
         </div>
 
         {/* Quick Actions */}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,10 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+
+export async function fetchApiInfo() {
+  const url = `${API_BASE_URL.replace(/\/$/, '')}/api`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status}`)
+  }
+  return response.json()
+}


### PR DESCRIPTION
## Summary
- connect frontend with backend using a new `fetchApiInfo` helper
- show API info on the homepage
- document API base URL environment variable in docs and example file
- adjust ESLint config for Node globals

## Testing
- `pnpm install --ignore-scripts`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686115acf204832f8e7ab58d372ca7dc