### PR TITLE
Fix base API URL handling

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -38,7 +38,8 @@ SECRET_KEY=flask-secret-key
 
 **Optie B: Vercel (Sneller)**
 - Ga naar **vercel.com** → Import repo → Root: `frontend`
-- Environment: `VITE_API_BASE_URL=https://your-railway-backend.railway.app/api`
+- Environment: `VITE_API_BASE_URL=https://your-railway-backend.railway.app`
+- Of kopieer `frontend/.env.example` naar `frontend/.env` en pas de URL aan (zonder `/api`)
 
 ## ✅ Klaar!
 

--- a/RAILWAY-DEPLOYMENT-GUIDE.md
+++ b/RAILWAY-DEPLOYMENT-GUIDE.md
@@ -106,7 +106,7 @@ SECRET_KEY=another-secret-key-for-flask-sessions
 4. **Root Directory:** `frontend`
 5. **Environment Variables:**
 ```bash
-VITE_API_BASE_URL=https://your-railway-backend-url.railway.app/api
+VITE_API_BASE_URL=https://your-railway-backend-url.railway.app
 ```
 
 ## 🔧 Configuratie Details
@@ -247,7 +247,8 @@ CNAME documentgenerator your-app.railway.app
 ### Frontend API Connection
 ```bash
 # Update frontend environment:
-VITE_API_BASE_URL=https://your-railway-backend-url.railway.app/api
+VITE_API_BASE_URL=https://your-railway-backend-url.railway.app
+# Of kopieer `frontend/.env.example` naar `frontend/.env` en pas de URL aan (zonder `/api`)
 
 # Of update nginx.conf proxy_pass:
 location /api/ {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL of your backend (no trailing /api)
+VITE_API_BASE_URL=https://your-backend-url.onrailway.app

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,7 +9,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.node },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import { FileText, Users, BarChart3, Settings, Plus, Download, Eye, Edit } from 'lucide-react'
 import { Button } from '@/components/ui/button.jsx'
@@ -8,10 +8,17 @@ import { Input } from '@/components/ui/input.jsx'
 import { Label } from '@/components/ui/label.jsx'
 import { Textarea } from '@/components/ui/textarea.jsx'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
+import { fetchApiInfo } from '@/lib/api.js'
 import './App.css'
 
 // Homepage Component
 function HomePage() {
+  const [apiInfo, setApiInfo] = useState(null)
+  useEffect(() => {
+    fetchApiInfo()
+      .then(setApiInfo)
+      .catch((err) => console.error('API error', err))
+  }, [])
   const stats = [
     { title: 'Documenten Gegenereerd', value: '1,234', icon: FileText, color: 'text-blue-600' },
     { title: 'Actieve Klanten', value: '89', icon: Users, color: 'text-green-600' },
@@ -52,6 +59,11 @@ function HomePage() {
         <div className="mb-8">
           <h2 className="text-3xl font-bold text-gray-900 mb-2">Welkom bij Document Generator</h2>
           <p className="text-lg text-gray-600">Genereer professionele documenten met gemak en snelheid</p>
+          {apiInfo && (
+            <pre className="mt-4 bg-gray-100 p-4 text-sm rounded">
+              {JSON.stringify(apiInfo, null, 2)}
+            </pre>
+          )}
         </div>
 
         {/* Quick Actions */}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,12 @@
+const RAW_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+// Support both with and without trailing `/api`
+const API_BASE_URL = RAW_BASE_URL.replace(/\/?$/, '')
+
+export async function fetchApiInfo() {
+  const base = API_BASE_URL.endsWith('/api') ? API_BASE_URL : `${API_BASE_URL}/api`
+  const response = await fetch(base)
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status}`)
+  }
+  return response.json()
+}


### PR DESCRIPTION
## Summary
- make API helper robust to VITE_API_BASE_URL with or without `/api`
- update Quick Start and deployment docs
- adjust `.env.example` accordingly

## Testing
- `pnpm install --ignore-scripts`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686115acf204832f8e7ab58d372ca7dc