### PR TITLE
Fix API base URL docs

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -38,7 +38,7 @@ SECRET_KEY=flask-secret-key
 
 **Optie B: Vercel (Sneller)**
 - Ga naar **vercel.com** → Import repo → Root: `frontend`
-- Environment: `VITE_API_BASE_URL=https://your-railway-backend.railway.app/api`
+ - Environment: `VITE_API_BASE_URL=https://your-railway-backend.railway.app`
 - Of kopieer `frontend/.env.example` naar `frontend/.env` en pas de URL aan
 
 ## ✅ Klaar!

--- a/RAILWAY-DEPLOYMENT-GUIDE.md
+++ b/RAILWAY-DEPLOYMENT-GUIDE.md
@@ -106,7 +106,7 @@ SECRET_KEY=another-secret-key-for-flask-sessions
 4. **Root Directory:** `frontend`
 5. **Environment Variables:**
 ```bash
-VITE_API_BASE_URL=https://your-railway-backend-url.railway.app/api
+VITE_API_BASE_URL=https://your-railway-backend-url.railway.app
 ```
 
 ## 🔧 Configuratie Details
@@ -247,7 +247,7 @@ CNAME documentgenerator your-app.railway.app
 ### Frontend API Connection
 ```bash
 # Update frontend environment:
-VITE_API_BASE_URL=https://your-railway-backend-url.railway.app/api
+VITE_API_BASE_URL=https://your-railway-backend-url.railway.app
 # Of kopieer `frontend/.env.example` naar `frontend/.env` en pas de URL aan
 
 # Of update nginx.conf proxy_pass:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://your-backend-url.onrailway.app/api
+VITE_API_BASE_URL=https://your-backend-url.onrailway.app

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/api\/?$/, '')
 
 export async function fetchApiInfo() {
   const url = `${API_BASE_URL.replace(/\/$/, '')}/api`


### PR DESCRIPTION
## Summary
- fix docs for `VITE_API_BASE_URL` so it doesn't include `/api`
- update example env file
- sanitize API base URL in `fetchApiInfo`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68611e775efc832fa112887fc08dcf6f